### PR TITLE
Convert $media_permissions to int in addMediaPermissionsInput and initialize selectable_roles array

### DIFF
--- a/classes/GUI/Form/class.xvmpVideoFormGUI.php
+++ b/classes/GUI/Form/class.xvmpVideoFormGUI.php
@@ -389,7 +389,7 @@ abstract class xvmpVideoFormGUI extends xvmpFormGUI
     {
         $media_permissions = xvmpConf::getConfig(xvmpConf::F_MEDIA_PERMISSIONS);
         if ($media_permissions) {
-            $input = $this->getMediaPermissionsInput($media_permissions);
+            $input = $this->getMediaPermissionsInput((int)$media_permissions);
             if (!empty($input->getOptions())) {
                 $this->addItem($input);
             }
@@ -403,6 +403,7 @@ abstract class xvmpVideoFormGUI extends xvmpFormGUI
         $input->setInfo($this->pl->txt(xvmpConf::F_MEDIA_PERMISSIONS . '_info'));
         $input->setRequired(true);
         $options = array();
+        $selectable_roles = array();
         if ($media_permissions == xvmpConf::MEDIA_PERMISSION_SELECTION) {
             $selectable_roles = xvmpConf::getConfig(xvmpConf::F_MEDIA_PERMISSIONS_SELECTION);
         }


### PR DESCRIPTION
Description: In one of our systems, xvmpConf::getConfig(xvmpConf::F_MEDIA_PERMISSIONS)  returns a string instead of an int. This causes issues with getMediaPermissionsInput as it expects an int value.

Additionally, further down in the function, the $selectable_roles array is not set if $media_permissions != xvmpConf::MEDIA_PERMISSION_SELECTION. To prevent issues later in the function, I’ve added an empty array to ensure it is always initialized.

Changes:

Added type check/handling for xvmpConf::getConfig(xvmpConf::F_MEDIA_PERMISSIONS) to ensure compatibility with getMediaPermissionsInput.
Initialized $selectable_roles as an empty array to avoid potential undefined array errors.