### PR TITLE
Cast $visible to int before passing to setVisible()

### DIFF
--- a/classes/GUI/class.xvmpSelectedVideosGUI.php
+++ b/classes/GUI/class.xvmpSelectedVideosGUI.php
@@ -79,7 +79,7 @@ class xvmpSelectedVideosGUI extends xvmpVideosGUI {
 		$visible = $_GET['visible'];
 		/** @var xvmpSelectedMedia $video */
 		$video = xvmpSelectedMedia::where(array('mid' => $mid, 'obj_id' => $this->getObjId()))->first();
-		$video->setVisible($visible);
+		$video->setVisible((int) $visible);
 		$video->update();
 		exit;
 	}


### PR DESCRIPTION
- Changed $video->setVisible($visible) to $video->setVisible((int) $visible)
- $_GET['visible'] returns a string, and setVisible() expects an integer
- Prevents potential issues caused by passing a string to setVisible()