### PR TITLE
Use null coalescing to set last_access_at to an empty string if null

### DIFF
--- a/classes/Model/API/class.xvmpUser.php
+++ b/classes/Model/API/class.xvmpUser.php
@@ -120,6 +120,7 @@ class xvmpUser extends xvmpObject {
 		$response = xvmpRequest::getUser($uid, array(
 			'roles' => 'true'
 		))->getResponseArray();
+	        $response['user']['last_access_at'] = $response['user']['last_access_at'] ?? '';
 		$xvmpUser = new self();
 		$xvmpUser->buildObjectFromArray($response['user']);
 		return $xvmpUser;


### PR DESCRIPTION
Use null coalescing for last_access_at to set it to an empty string if null,  to avoid issues where a string is expected